### PR TITLE
do not add upsEstimatedMinutesRemaining to perfdata if is an empty st…

### DIFF
--- a/plugins-scripts/Classes/UPS/Components/BatterySubsystem.pm
+++ b/plugins-scripts/Classes/UPS/Components/BatterySubsystem.pm
@@ -73,10 +73,13 @@ sub check {
     # higher thresholds set by warningx/criticalx
     $self->add_ok('unit is not on battery power');
   }
-  $self->add_perfdata(
-      label => 'remaining_time',
-      value => $self->{upsEstimatedMinutesRemaining},
-  );
+
+  if ($self->{upsEstimatedMinutesRemaining} ne '') {
+    $self->add_perfdata(
+        label => 'remaining_time',
+        value => $self->{upsEstimatedMinutesRemaining},
+    );
+  }
 
   if (defined $self->{upsEstimatedChargeRemaining}) {
     $self->set_thresholds(


### PR DESCRIPTION
Enconnex AC6000 seems to return NULL for upsEstimatedMinutesRemaining when the battery is not used.

```
[honza@archlinux }$ snmpwalk  -v 2c -c public $device  1.3.6.1.2.1.33.1.2.3.0
SNMPv2-SMI::mib-2.33.1.2.3.0 = NULL
```

Which causes this behavior

```
[honza@archlinux ]$ perl ./check_ups_health --hostname $device --mode battery-health  --community public -t 3600  
Use of uninitialized value $value in sprintf at check_ups_health line 585.
OK - temperature is 28.00C, unit is not on battery power, capacity is 95.00%, output load0 0.00% | 'battery_temperature'=28;35;38;; 'remaining_time'=;0:;0:;; 'capacity'=95%;25:;10:;0;100 'battery_voltage'=19.80;;;; 'output_frequency'=60;;;; 'input_voltage0'=202;;;; 'input_frequency0'=60;;;; 'output_load0'=0%;75;85;0;100 'output_voltage0'=200;;;; 'output_current0'=8.30;;;; 'output_power0'=1624;;;;
```

Signed-off-by: Jan Tlusty <j.tlusty@gmail.com>